### PR TITLE
fix: ignore empty choices

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -212,9 +212,11 @@ function handleResponse(query, targetText, textFromResponse) {
     if (textFromResponse !== '[DONE]') {
         try {
             const dataObj = JSON.parse(textFromResponse);
+            // https://github.com/openai/openai-node/blob/master/src/resources/chat/completions.ts#L190
             const { choices } = dataObj;
-            if (choices && choices[0] && choices[0].delta.content) {
-                targetText += choices[0].delta.content;
+            const delta = choices[0]?.delta?.content;
+            if (delta) {
+                targetText += delta;
                 query.onStream({
                     result: {
                         from: query.detectFrom,

--- a/src/main.js
+++ b/src/main.js
@@ -213,20 +213,8 @@ function handleResponse(query, targetText, textFromResponse) {
         try {
             const dataObj = JSON.parse(textFromResponse);
             const { choices } = dataObj;
-            if (!choices || choices.length === 0) {
-                query.onCompletion({
-                    error: {
-                        type: "api",
-                        message: "接口未返回结果",
-                        addtion: textFromResponse,
-                    },
-                });
-                return targetText;
-            }
-
-            const content = choices[0].delta.content;
-            if (content !== undefined) {
-                targetText += content;
+            if (choices && choices[0] && choices[0].delta.content) {
+                targetText += choices[0].delta.content;
                 query.onStream({
                     result: {
                         from: query.detectFrom,


### PR DESCRIPTION
resolve #99

避免使用 openai 代理时报错“接口未返回结果”。

![519683807574acebada115ade9986a06](https://github.com/openai-translator/bob-plugin-openai-translator/assets/22350366/8c3fcd7d-1293-4e06-8ffe-60f16b92c5ad)


这样修改的原因是参考了 `ChatGPT Next Web` 的 [这段代码](https://github.com/Yidadaa/ChatGPT-Next-Web/blob/main/app/client/platforms/openai.ts#L207)，当 choice content 为空时不报错，仅仅忽略。

可以[在这里](https://github.com/Nomango/bob-plugin-openai-translator/releases/tag/v2.1.3)下载打包程序以进行测试。